### PR TITLE
Fixed call vital#of().

### DIFF
--- a/autoload/neocomplete/util.vim
+++ b/autoload/neocomplete/util.vim
@@ -28,8 +28,8 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let s:V = vital#of('neocomplete')
-let s:List = vital#of('neocomplete').import('Data.List')
-let s:String = vital#of('neocomplete').import('Data.String')
+let s:List = s:V.import('Data.List')
+let s:String = s:V.import('Data.String')
 
 function! neocomplete#util#truncate_smart(...) "{{{
   return call(s:V.truncate_smart, a:000)


### PR DESCRIPTION
`vital#of('neocomplete')` の呼び出しが重複していたので修正しました。
