### PR TITLE
only include relative soruce when context input is relative

### DIFF
--- a/autoload/neocomplete/sources/file_include.vim
+++ b/autoload/neocomplete/sources/file_include.vim
@@ -172,6 +172,11 @@ function! s:get_include_files(complete_str) "{{{
   let candidates = s:get_default_include_files(filetype)
   for subpath in split(path, '[,;]')
     let dir = (subpath == '.') ? bufdirectory : subpath
+
+    if (complete_str[0] == '.' && subpath[0] != '.')
+        continue
+    endif
+
     if !isdirectory(dir)
       continue
     endif


### PR DESCRIPTION
when I'm importing a library start by `.` like `./lib/`, I'm not want to get files in global path like `/usr/include`, so I let file_include souce only search relative path when context input is relative.
