### PR TITLE
don't source rest of file if no lua or correct version

### DIFF
--- a/plugin/neocomplete.vim
+++ b/plugin/neocomplete.vim
@@ -35,6 +35,7 @@ set cpo&vim
 if !( has('lua') && (v:version > 703 || v:version == 703 && has('patch885')) )
   echomsg 'neocomplete does not work this version of Vim.'
   echomsg 'It requires Vim 7.3.885 or above and "if_lua" enabled Vim.'
+  finish
 endif
 
 command! -nargs=0 -bar NeoCompleteEnable


### PR DESCRIPTION
If lua is not there the script continues to execute and that creates a lot of errors when editing text like for example:

function neocomplete#handler#_do_auto_complete..neocomplete#complete#_set_results_pos..12..neocompl
ete#get_keyword_pattern_end..neocomplete#get_keyword_pattern..neocomplete#helper#unite_patterns, li
ne 3
Press ENTER or type command to continue

a lot of this messages appear. This seems to fix it.
