### PR TITLE
ドキュメントのjediサポートの部分の正規表現

### DIFF
--- a/doc/neocomplete.txt
+++ b/doc/neocomplete.txt
@@ -1790,7 +1790,8 @@ A: Please set |g:neocomplete#force_omni_input_patterns| as below.
 >
 	autocmd FileType python setlocal omnifunc=jedi#completions
 	let g:jedi#auto_vim_configuration = 0
-	let g:neocomplete#force_omni_input_patterns.python = '[^. \t]\.\w*'
+	let g:neocomplete#force_omni_input_patterns.python =
+	\ '\%([^. \t]\.\|^\s*@\|^\s*from\s.\+import \|^\s*from \|^\s*import \)\w*'
 <
 Q: Candidates are not found in heavy completion(neco-look, etc).
 


### PR DESCRIPTION
jedi有効時の設定例を、プロパティとモジュールのインポート時にもオムニ補完が効くものにしました。
