### PR TITLE
Remove the processing which deletes menu

### DIFF
--- a/autoload/neocomplete/complete.vim
+++ b/autoload/neocomplete/complete.vim
@@ -175,7 +175,6 @@ function! neocomplete#complete#_get_words(sources, complete_pos, complete_str) "
   " Append prefix.
   let candidates = []
   let len_words = 0
-  let sources_len = 0
   for source in sort(filter(copy(a:sources),
         \ '!empty(v:val.neocomplete__context.candidates)'),
         \  's:compare_source_rank')
@@ -240,7 +239,6 @@ EOF
 
     let candidates += words
     let len_words += len(words)
-    let sources_len += 1
 
     if g:neocomplete#max_list > 0
           \ && len_words > g:neocomplete#max_list
@@ -254,22 +252,6 @@ EOF
 
   if g:neocomplete#max_list > 0
     let candidates = candidates[: g:neocomplete#max_list]
-  endif
-
-  if sources_len == 1
-    " Remove default menu.
-    lua << EOF
-    do
-      local candidates = vim.eval('candidates')
-      local mark = vim.eval('mark')
-      local sources_len = vim.eval('sources_len')
-      for i = 0, #candidates-1 do
-        if candidates[i].menu == mark then
-          candidates[i].menu = nil
-        end
-      end
-    end
-EOF
   endif
 
   " Check dup and set icase.


### PR DESCRIPTION
いつもお世話になっています:)
バグを発見したので、PRしますー
## 問題

補完候補のsourceが1種類のときに、markが表示されません。
下記の画像では、本来`[D]`が表示されるべきですがmarkが削除されています。

![2014-01-06 1 47 19](https://f.cloud.github.com/assets/1688137/1846928/11337968-7629-11e3-928b-d3f1915642df.png)
## 原因

原因を調べたところ、先日ファイル補完について、修正してくださったコミットのようです。
https://github.com/Shougo/neocomplete.vim/issues/132

[sources_lenが1のときにmarkを削除している処理](https://github.com/Shougo/neocomplete.vim/blob/8d76fcef8aa6146ed45e2ba810afa59f752b3828/autoload/neocomplete/complete.vim#L252)が原因と思われます。
## 解決策

候補がひとつのときに、markを削除しなくてもいいと思います:) (今回のPRデス)

あるいは、file補完のときだけ例外で処理するようにすべきですかね。
