### PR TITLE
Restore ignore case setting for a return path in neocomplete#complete#_s...

### DIFF
--- a/autoload/neocomplete/complete.vim
+++ b/autoload/neocomplete/complete.vim
@@ -349,6 +349,7 @@ function! neocomplete#complete#_set_results_words(sources) "{{{
 
   for source in a:sources
     if neocomplete#complete_check()
+      let &ignorecase = ignorecase_save
       return
     endif
 


### PR DESCRIPTION
...et_results_words

I noticed that my `ignorecase` setting was changing sometimes and saw that it was last set by neocomplete. I tracked it down to this function which has a `return` that doesn't restore the original setting.
