### PR TITLE
bug? fix

### DIFF
--- a/autoload/neocomplete/sources/buffer.vim
+++ b/autoload/neocomplete/sources/buffer.vim
@@ -30,7 +30,7 @@ set cpo&vim
 let g:neocomplete#sources#buffer#cache_limit_size =
       \ get(g:, 'neocomplete#sources#buffer#cache_limit_size', 500000)
 let g:neocomplete#sources#buffer#disabled_pattern =
-      \ get(g:, 'neocomplete#sources#buffer#disabled_pattern', '')
+      \ get(g:, 'neocomplete#sources#buffer#disabled_pattern', '"')
 let g:neocomplete#sources#buffer#max_keyword_width =
       \ get(g:, 'neocomplete#sources#buffer#max_keyword_width', 80)
 "}}}
@@ -137,7 +137,7 @@ endfunction"}}}
 function! s:should_create_cache() " {{{
   let filepath = fnamemodify(bufname('%'), ':p')
   return getfsize(filepath) < g:neocomplete#sources#buffer#cache_limit_size &&
-          \ filepath =~# g:neocomplete#sources#buffer#disabled_pattern
+          \ filepath !~# g:neocomplete#sources#buffer#disabled_pattern
 endfunction"}}}
 
 function! s:make_cache_current_buffer(start, end) "{{{


### PR DESCRIPTION
日本語で失礼します。
vimscriptにそれほど明るくないので恐縮ですが、
やりたいのは「disabled_pattern に 正規表現マッチしたらキャッシュを取らない」
だと思います。
!~#だと正規表現非マッチなので、バッファ補完が全く効かなくなると思います。
補完候補に[B]が全く出て来なかったので気になってPRしました。
