### PR TITLE
Avoid reprocessing modeline

### DIFF
--- a/autoload/neocomplete/init.vim
+++ b/autoload/neocomplete/init.vim
@@ -44,9 +44,12 @@ function! neocomplete#init#enable() "{{{
   call neocomplete#init#_sources(get(g:neocomplete#sources,
         \ neocomplete#get_context_filetype(), ['_']))
 
-  if mode() ==# 'i'
-    doautocmd neocomplete InsertEnter
-  endif
+  let modeline_save = &modeline
+  set nomodeline
+
+  doautocmd neocomplete InsertEnter
+
+  let &modeline = modeline_save
 
   let s:is_enabled = 1
 endfunction"}}}


### PR DESCRIPTION
#188

> If you set updatetime to a large enough number that you have time to open the fold, go somewhere inside of it and hit `A` or `I`, insert mode is entered and the fold is closed, which is very disorienting.

こっち (`CursorMovedI`で発動) は直っていません。
一旦 `nomodeline` に設定することで対処しました。
