### PR TITLE
Fixed typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Which package depends on your graphical environment (except vim-nox which is for
 #### Fedora 
 
 The latest version of vim includes lua.
-As of 2014-04-16 you need to (download the rmp)[http://koji.fedoraproject.org/koji/packageinfo?packageID=216].
+As of 2014-04-16 you need to (download the rpm)[http://koji.fedoraproject.org/koji/packageinfo?packageID=216].
 
 #### Misc
 


### PR DESCRIPTION
rmp -> rpm
