### PR TITLE
Allow manual indentation of line in insert mode

### DIFF
--- a/autoload/neocomplete/handler.vim
+++ b/autoload/neocomplete/handler.vim
@@ -171,17 +171,21 @@ function! neocomplete#handler#_on_text_changed() "{{{
     call s:make_cache_current_line()
   endif
 
-  let cur_text = matchstr(getline('.'), '^.*\%'.col('.').'c')
   " indent line matched by indentkeys
-  for word in filter(map(split(&l:indentkeys, ','),
+  let neocomplete = neocomplete#get_current_neocomplete()
+  let cur_text = matchstr(getline('.'), '^.*\%'.col('.').'c')
+  if get(neocomplete, 'indent_text', '') != matchstr(getline('.'), '\S.*$')
+    for word in filter(map(split(&l:indentkeys, ','),
         \ "v:val =~ '^<.*>$' ? matchstr(v:val, '^<\\zs.*\\ze>$')
         \                  : matchstr(v:val, '.*=\\zs.*')"),
         \ "v:val != ''")
-    if stridx(cur_text, word, len(cur_text)-len(word)-1) >= 0
-      call neocomplete#helper#indent_current_line()
-      break
-    endif
-  endfor
+      if stridx(cur_text, word, len(cur_text)-len(word)-1) >= 0
+        call neocomplete#helper#indent_current_line()
+        let neocomplete.indent_text = matchstr(getline('.'), '\S.*$')
+        break
+      endif
+    endfor
+  endif
 endfunction"}}}
 
 function! neocomplete#handler#_do_auto_complete(event) "{{{

--- a/autoload/neocomplete/handler.vim
+++ b/autoload/neocomplete/handler.vim
@@ -174,7 +174,7 @@ function! neocomplete#handler#_on_text_changed() "{{{
   " indent line matched by indentkeys
   let neocomplete = neocomplete#get_current_neocomplete()
   let cur_text = matchstr(getline('.'), '^.*\%'.col('.').'c')
-  if get(neocomplete, 'indent_text', '') != matchstr(getline('.'), '\S.*$')
+  if neocomplete.indent_text != matchstr(getline('.'), '\S.*$')
     for word in filter(map(split(&l:indentkeys, ','),
         \ "v:val =~ '^<.*>$' ? matchstr(v:val, '^<\\zs.*\\ze>$')
         \                  : matchstr(v:val, '.*=\\zs.*')"),

--- a/autoload/neocomplete/init.vim
+++ b/autoload/neocomplete/init.vim
@@ -621,6 +621,7 @@ function! neocomplete#init#_current_neocomplete() "{{{
         \ 'sources_filetype' : '',
         \ 'within_comment' : 0,
         \ 'is_auto_complete' : 0,
+        \ 'indent_text' : '',
         \}
 endfunction"}}}
 


### PR DESCRIPTION
This change allows manually changing the indent of a line using `<C-d>`/`<C-t>` in insert mode. Currently, the logic indents the line automatically whenever the text changed, but this makes it reindent only if the part of the line after the leading whitespace changed since the last auto-indent.

For example, starting with:
```python
def a():
    pass
```
If I open a new line under `a()` like
```python
def a():
    def b():  # cursor on the :
    pass
```
then press `<C-d>` to shift the line one shiftwidth left to make it
```python
def a():
def b():
    pass
```
then neocomplete moves it back to the right.