### PR TITLE
Fix use of hasmapto

### DIFF
--- a/autoload/neocomplete/mappings.vim
+++ b/autoload/neocomplete/mappings.vim
@@ -38,10 +38,10 @@ function! neocomplete#mappings#define_default_mappings() "{{{
         \neocomplete#mappings#popup_post()<CR>
 
   " To prevent Vim's complete() bug.
-  if !hasmapto("\<C-h>", 'i')
+  if !hasmapto('<C-h>', 'i')
     inoremap <expr><C-h> neocomplete#smart_close_popup()."\<C-h>"
   endif
-  if !hasmapto("\<BS>", 'i')
+  if !hasmapto('<BS>', 'i')
     inoremap <expr><BS> neocomplete#smart_close_popup()."\<C-h>"
   endif
 endfunction"}}}


### PR DESCRIPTION
`hasmapto("\<BS>")` returns `0` even if `<BS>` is mapped:

```vim
:silent! iunmap <BS>
:silent! iunmap <buffer> <BS>
:echo hasmapto("\<BS>", 'i')
" 0
:inoremap <BS> <BS>
:echo hasmapto("\<BS>", 'i')
" 0
:inoremap <expr><BS> neocomplete#smart_close_popup()."\<C-h>"
:echo hasmapto("\<BS>", 'i')
" 0
:echo hasmapto('<BS>', 'i')
" 1
```