### PR TITLE
Fix mapping check

### DIFF
--- a/autoload/neocomplete/mappings.vim
+++ b/autoload/neocomplete/mappings.vim
@@ -38,10 +38,10 @@ function! neocomplete#mappings#define_default_mappings() "{{{
         \neocomplete#mappings#popup_post()<CR>
 
   " To prevent Vim's complete() bug.
-  if !hasmapto('<C-h>', 'i')
+  if mapcheck('<C-h>', 'i') ==# ''
     inoremap <expr><C-h> neocomplete#smart_close_popup()."\<C-h>"
   endif
-  if !hasmapto('<BS>', 'i')
+  if mapcheck('<BS>', 'i') ==# ''
     inoremap <expr><BS> neocomplete#smart_close_popup()."\<C-h>"
   endif
 endfunction"}}}


### PR DESCRIPTION
`<BS>`と`<C-h>`の定義が上書きされています。
定義してる所を見ると、チェック方法に誤りがありました。
map の左辺が定義されているかチェックするには `hasmapto()` ではなく、 `maparg()` か `mapcheck()` を使用します。
念のため誤爆が少なくなりそうな `mapcheck()` を使って修正しました。

※参考
http://vim.wikia.com/wiki/Mapping_keys_in_Vim_-_Tutorial_%28Part_3%29

何か問題があればご指摘お願いします。
