### PR TITLE
vital: use globpath without suffixes and wildignore

### DIFF
--- a/autoload/vital.vim
+++ b/autoload/vital.vim
@@ -1,5 +1,5 @@
 function! vital#of(name)
-  let files = globpath(&runtimepath, 'autoload/vital/' . a:name . '.vital')
+  let files = globpath(&runtimepath, 'autoload/vital/' . a:name . '.vital', 1)
   let file = split(files, "\n")
   if empty(file)
     throw 'vital: version file not found: ' . a:name


### PR DESCRIPTION
wildignore settings might make the "autoload/vital/XXX.vital" files
invisible.

It's related to Shougo/neocomplcache.vim#372

I wanted to use `s:_runtime_files(path)` from "autoload/vital/neocomplete.vim" but I don't know anything about vimscripts.