### PR TITLE
Updates macvim homebrew installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ file in the same directory as `gvim.exe`.
 
 Or, you can install MacVim with homebrew:
 
-    brew install macvim --with-cscope --with-lua --HEAD
+    brew install macvim --with-cscope --with-lua
+    brew linkapps macvim
 
 To install Vim (as opposed to MacVim) with homebrew:
 


### PR DESCRIPTION
We no longer need to build with `--HEAD` and the `linkapps` command prevents the nasty `[neocomplete] You installed MacVim in not default directory!` warning.