### PR TITLE
Make error message for vim<7.3.885 clearer ("It" -> "neocomplete")

### DIFF
--- a/autoload/neocomplete/init.vim
+++ b/autoload/neocomplete/init.vim
@@ -37,7 +37,7 @@ function! neocomplete#init#enable() "{{{
 
   if !(has('lua') && (v:version > 703 || v:version == 703 && has('patch885')))
     echomsg 'neocomplete does not work with this version of Vim.'
-    echomsg 'It requires Vim 7.3.885 or later with Lua support ("+lua").'
+    echomsg 'neocomoplete requires Vim 7.3.885 or later with Lua support ("+lua").'
     return
   endif
 


### PR DESCRIPTION
As only the last error message is shown, it wasn't obvious which plugin had a problem. Now it should be.