### PR TITLE
Fix path completion not shown

### DIFF
--- a/autoload/neocomplete/sources/file.vim
+++ b/autoload/neocomplete/sources/file.vim
@@ -34,6 +34,7 @@ let s:source = {
       \ 'sorters' : 'sorter_filename',
       \ 'converters' : ['converter_remove_overlap', 'converter_abbr'],
       \ 'is_volatile' : 1,
+      \ 'input_pattern': '/',
       \}
 
 function! s:source.get_complete_position(context) "{{{


### PR DESCRIPTION
I noticed after ad08ad6c340905fa9007081e10dc258cbe5b3a43 the path does not get completed. I may be doing something wrong (in particular, I wasn't sure if I could use `/` or need to account for Windows `\` separator) so please let me know if any further change is needed.

This also happens when using with neoinclude.vim (like `#include <linux/`).

## Environment
* Gentoo Linux
* Vim 7.4 patch 1184

## Minimal vimrc
```vim
if has('vim_starting')
  set nocompatible
  set runtimepath+=~/.vim/bundle/neocomplete.vim
endif

let g:neocomplete#enable_at_startup = 1

call neocomplete#initialize()
```

## Steps to reproduce
0. `git checkout ad08ad6c340905fa9007081e10dc258cbe5b3a43`
1. `vim -u ~/vimrc`
2. Type `/home/`
3. No completion is shown.

## Expected
User names to appear as completion when typing `/home/`.
