### PR TITLE
Add source__sources variable to Unite source

### DIFF
--- a/autoload/unite/sources/neocomplete.vim
+++ b/autoload/unite/sources/neocomplete.vim
@@ -47,6 +47,8 @@ function! s:neocomplete_source.hooks.on_init(args, context) abort "{{{
   let max_list_save = g:neocomplete#max_list
   let max_keyword_width_save = g:neocomplete#max_keyword_width
   let manual_start_length = g:neocomplete#manual_completion_start_length
+  let neocomplete = neocomplete#get_current_neocomplete()
+  let sources_save = get(neocomplete, 'sources', {})
 
   try
     let g:neocomplete#max_list = -1
@@ -54,7 +56,12 @@ function! s:neocomplete_source.hooks.on_init(args, context) abort "{{{
     let g:neocomplete#manual_completion_start_length = 0
 
     let cur_text = neocomplete#get_cur_text(1)
-    let complete_sources = neocomplete#complete#_get_results(cur_text)
+    let sources = get(a:context, 'source__sources', [])
+    let args = [cur_text]
+    if !empty(sources)
+      call add(args, neocomplete#helper#get_sources_list(sources))
+    endif
+    let complete_sources = call('neocomplete#complete#_get_results', args)
     let a:context.source__complete_pos =
           \ neocomplete#complete#_get_complete_pos(complete_sources)
     let a:context.source__candidates = neocomplete#complete#_get_words(
@@ -65,6 +72,8 @@ function! s:neocomplete_source.hooks.on_init(args, context) abort "{{{
     let g:neocomplete#max_list = max_list_save
     let g:neocomplete#max_keyword_width = max_keyword_width_save
     let g:neocomplete#manual_completion_start_length = manual_start_length
+    let neocomplete.sources = empty(sources_save) ?
+          \ neocomplete#helper#get_sources_list() : sources_save
   endtry
 endfunction"}}}
 


### PR DESCRIPTION
This makes it possible to start completion with Unite with only specific sources. For example:

```vim
function! s:start_unite_complete(sources) abort " {{{
    let text = neocomplete#get_cur_text(1)
    let sources = neocomplete#complete#_set_results_pos(text)
    return unite#start_complete(['neocomplete'], {
        \ 'source__sources' : a:sources, 'auto_preview' : 1, 'here' : 0,
        \ 'resize' : 0, 'split' : 0, 'input' : escape(tolower(
        \ text[neocomplete#complete#_get_complete_pos(sources): ]),
        \ '~\.^$[]*') . ' '})
endfunction " }}}
inoremap <silent> <expr> <C-x><C-@> <SID>start_unite_complete(['tmux-complete'])
```