### PR TITLE
Update Readme - install Macvim using `brew cask`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ file in the same directory as `gvim.exe`.
 
 Or, you can install MacVim with homebrew:
 
-    brew install macvim --with-cscope --with-lua
-    brew linkapps macvim
+    brew cask install macvim --with-cscope --with-lua
 
 To install Vim (as opposed to MacVim) with homebrew:
 


### PR DESCRIPTION
Apps linked by `linkapps` cannot be found by spotlight.
The fix is to use `brew cask` instead of `brew`.

Tested with `brew cask` and verified ✅ 

See https://github.com/Homebrew/legacy-homebrew/issues/28798