### PR TITLE
Fixed two bug years ago

### DIFF
--- a/autoload/neocomplete/complete.vim
+++ b/autoload/neocomplete/complete.vim
@@ -118,15 +118,15 @@ EOF
       continue
     endif
 
-    if source.max_candidates > 0
-      let words = words[: len(source.max_candidates)-1]
-    endif
-
     let words = neocomplete#helper#call_filters(
           \ source.neocomplete__converters, source, {})
 
     if empty(words)
       continue
+    endif
+
+    if source.max_candidates > 0
+      let words = words[: source.max_candidates -1]
     endif
 
     " Set default menu.

--- a/autoload/neocomplete/complete.vim
+++ b/autoload/neocomplete/complete.vim
@@ -130,7 +130,7 @@ EOF
     endif
 
     " Set default menu.
-    if get(words[0], 'menu', '') !~ '^\[.*\'
+    if get(words[0], 'menu', '') !~ '^\[.*\]'
       call s:set_default_menu(words, source)
     endif
 


### PR DESCRIPTION
Line 133
miss a char `]` in regex pattern. 
so it a bad pattern.
condidates of ultisnips will display `[US]` mark two times.

Line 128
the source code logical order causes the option `source.max_candidates` not effect.