### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ installed)
 
 To install Vim (as opposed to MacVim) with homebrew:
 
-    brew install vim --with-lua
+    brew install vim --with-luajit
 
 ### Vim for Linux:
 


### PR DESCRIPTION
installing vim via homebrew no longer accepts `--with-lua` option, it's been deprecated in favor of `--with-luajit`